### PR TITLE
Fix redirect in case of auth error

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,7 +111,7 @@ def callback():
 
     except Exception as e:
         print("Error authenticating with code", e)
-        return redirect(url_for("/login"))
+        return redirect(url_for("login"))
 
 
 @app.route("/login")


### PR DESCRIPTION
If, hypothetically, the end user doesn't provide the right `cookie_password`, they will encounter a BuildError when `workos.user_management.authenticate_with_code()` fails. This update will redirect to the main login page as intended. Thanks!